### PR TITLE
edit-article-css

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -1,7 +1,6 @@
 class ArticlesController < ApplicationController
   before_action :set_article, only: [:show, :edit, :update, :destroy]
   before_action :authenticate_user!, except: [:index, :show]  
-  include ApiHelper
   # GET /articles
   # GET /articles.json
   def index

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -25,7 +25,7 @@
 <% @articles1.each do |article| %>
 <div class="card">
   <div class="row no-gutters">
-    <div class="col-md-4" style = "height:auto;">
+    <div class="col-md-4" style = "max-height: 250px;">
       <img src="<%= article["urlToImage"] %>" class="card-img" alt="news-image" style = "height:100%;">
     </div>
     <div class="col-md-8">


### PR DESCRIPTION
海外トピックスの記事の高さにバラツキがあったため、CSSを変更
api_helperをincludeしたことによる、herokuのエラーも対処